### PR TITLE
MQTT Recorder

### DIFF
--- a/MqttRecorder.py
+++ b/MqttRecorder.py
@@ -1,0 +1,39 @@
+from Measurement import Measurement
+from Recorders import Recorder
+import json
+import paho.mqtt.client as mqtt
+
+class MqttRecorder(Recorder):
+    def __init__(self, config):
+        Recorder.__init__(self, 'mqtt')
+        self.format = config['format']
+        
+        self.host = config['host']
+        self.port = config['port'] if 'port' in config else 1883
+        self.topic = config['topic']
+        self.client_id = config['client_id']
+        self.username = config['username']
+        self.password = config['password']
+        self.timeout = config['timeout'] if 'timeout' in config else 30
+        self.qos = config['qos'] if 'qos' in config else 1
+        self.client = None
+
+    def _open_client(self):
+        self.client = mqtt.Client(self.client_id)
+        self.client.username_pw_set(self.username, self.password)
+        self.client.connect(self.host, self.port, self.timeout)
+    
+    def get_client(self):
+        if self.client == None:
+            self._open_client()
+        return self.client
+            
+    def record(self, measure: Measurement):
+        payload = self.format.format(
+            device_id=measure.device_id,
+            celsius=measure.get_celsius(),
+            fahrenheit=measure.get_fahrenheit(),
+            timestamp=measure.timestamp)
+        
+        client = self.get_client()
+        client.publish(self.topic, payload, qos=self.qos, retain=False)

--- a/MqttRecorder.py
+++ b/MqttRecorder.py
@@ -21,6 +21,7 @@ class MqttRecorder(Recorder):
     def _open_client(self):
         self.client = mqtt.Client(self.client_id)
         self.client.username_pw_set(self.username, self.password)
+        self.client.on_disconnect = lambda client,userdata,rc: self._open_client()
         self.client.connect(self.host, self.port, self.timeout)
     
     def get_client(self):
@@ -37,3 +38,4 @@ class MqttRecorder(Recorder):
         
         client = self.get_client()
         client.publish(self.topic, payload, qos=self.qos, retain=False)
+        client.loop_misc()

--- a/RecorderFactory.py
+++ b/RecorderFactory.py
@@ -1,4 +1,5 @@
 from Recorders import Recorder, PrintRecorder, FileRecorder
+from MqttRecorder import MqttRecorder
 
 def create_print_recorder(config):
     return PrintRecorder(config)
@@ -6,7 +7,11 @@ def create_print_recorder(config):
 def create_file_recorder(config):
     return FileRecorder(config)
 
+def create_mqtt_recorder(config):
+    return MqttRecorder(config)
+
 recorderInitializers = dict([
+    ('mqtt', create_mqtt_recorder),
     ('print', create_print_recorder),
     ('file', create_file_recorder)])
 

--- a/config.json
+++ b/config.json
@@ -14,6 +14,20 @@
                 "container": "/temperaturemonitor/",
                 "extension": ".log"
             }
+        },
+        {
+            "type": "mqtt",
+            "config": {
+                "format": "{timestamp},{celsius},C",
+                "host": "192.168.9.49",
+		"port": 1883,
+		"client_id": "sensor-1",
+		"username": "sensor",
+		"password": "sensor",
+		"topic": "sensor/sensor1",
+		"timeout": 30,
+		"qos": 1
+            }
         }
     ]
 }


### PR DESCRIPTION
Refer to http://www.steves-internet-guide.com/into-mqtt-python-client/ as an example on how to set up the paho mqtt client. On the MQTT broker (mosquitto works fine), verify the MQTT Recorder works by running, for example: `mosquitto_sub -h 127.0.0.1 -p 1883 -u sensor -P sensor -t 'sensor/sensor1'`

(The config.json contains a sample config for my test mqtt server)