### PR TITLE
Http recorder

### DIFF
--- a/HttpRecorder.py
+++ b/HttpRecorder.py
@@ -23,9 +23,9 @@ class HttpRecorder(Recorder):
     def __init__(self, config):
         Recorder.__init__(self, 'http')
         print("http recorder init")
-        self.template = config['json_template']
-        self.method = config['method']
-        self.url = config['endpoint']
+        
+        self.url = config['uri']
+        self.template = config['json-template']
         self.headers = config['headers']
         self.headers['content-type'] = 'application/json'
 

--- a/HttpRecorder.py
+++ b/HttpRecorder.py
@@ -1,0 +1,43 @@
+from Measurement import Measurement
+from Recorders import Recorder
+import json
+import urllib.request
+import sys
+
+def dict_format(template, measure: Measurement):
+    d = {}
+    # iterate over items in the dict
+    for key, item in template.items():
+        # if the item is a string, apply format
+        if type(item) == str:
+            formatted_value = item.format(
+                device_id=measure.device_id,
+                celsius=measure.get_celsius(),
+                fahrenheit=measure.get_fahrenheit(),
+                timestamp=measure.timestamp)
+            d[key] = formatted_value
+    return d
+
+
+class HttpRecorder(Recorder):
+    def __init__(self, config):
+        Recorder.__init__(self, 'http')
+        print("http recorder init")
+        self.template = config['json_template']
+        self.method = config['method']
+        self.url = config['endpoint']
+        self.headers = config['headers']
+        self.headers['content-type'] = 'application/json'
+
+    def record(self, measure: Measurement):
+        # First, generate payload
+        payload = dict_format(self.template, measure)
+        j = json.dumps(payload).encode('utf8')
+
+        # Construct url
+        url = self.url.format(device_id = measure.device_id)
+
+        # submit
+        req = urllib.request.Request(url, data=j, headers=self.headers)
+        response = urllib.request.urlopen(req)
+        sys.stderr.write(response.read().decode('utf8'))

--- a/README.md
+++ b/README.md
@@ -2,21 +2,33 @@
 
 Python application to read DS18B20 1-wire temperature sensor and sends data to configured recorders. Read frequency can be configured in `config.json` by setting the property `read-interval` in seconds.
 
-    {
-        "read-interval": 30
-    }
+```json
+{
+    "read-interval": 30
+}
+```
 
 ## Recorders
 
-A recorder is where the data read from the sensor will be sent. Multiple recorders can be configured at the same time using config.json
+A recorder is where the data read from the sensor will be sent. Multiple recorders can be configured at the same time using config.json.
 
 Existing recorders are:
 
 - Print
 - File
-- _Http_ (under development)
+- Http
 
-Some recorders has a `format` configuration that can be used to format the output of the data. Fields that can be used in the string format are:
+A Measurement object will be passed to each configured recorder each time the sensor is read. This object has following structure:
+
+```json
+{
+    "device_id": "28ABCDEF123456",
+    "value": 130.123,
+    "timestamp": "2017-10-06T07:49:51Z"
+}
+```
+
+Recorders has some configuration fields that accepts dynamic values from Measurement. To use a dynamic valye it must be referenced using braces (i.e. `{device_id}`). Fields that can be used as dynamic values are:
 
 - **device_id**: the id of the sensor read
 - **timestamp**: date and time of the read
@@ -25,28 +37,60 @@ Some recorders has a `format` configuration that can be used to format the outpu
 
 ### Print recorder
 
-Print the data received through the console using the string format configured in `format`.
+Print the data received through the console using the string format configured in `format`. `format`configuration accepts dynamic values.
 
-    {
-        "recorders": [{
-            "type": "print",
-            "config": {
-                "format": "{device_id} C {celsius} / F {fahrenheit}"
-            }
-        }]
-    }
+Example configuration:
+
+```json
+{
+    "recorders": [{
+        "type": "print",
+        "config": {
+            "format": "{device_id} C {celsius} / F {fahrenheit}"
+        }
+    }]
+}
+```
 
 ### File recorder
 
-This recorder will create a file for each sensor read using the device id of the sensor as file name. The files will be stored in the path configured in `container` with the extension specified in `extension`. The data read from the sensor will be write using the string format in `format`.
+This recorder will create a file for each sensor read using the device id of the sensor as file name. The files will be stored in the path configured in `container` with the extension specified in `extension`. The data read from the sensor will be write using the string format in `format`. `format`configuration accepts dynamic values.
 
-    {
-        "recorders": [{
-            "type": "file",
-            "config": {
-                "format": "{timestamp},{celsius},C",
-                "container": "/temperature/",
-                "extension": ".log"
-            }
-        }]
-    }
+Example configuration:
+
+```json
+{
+    "recorders": [{
+        "type": "file",
+        "config": {
+            "format": "{timestamp},{celsius},C",
+            "container": "/temperature/",
+            "extension": ".log"
+        }
+    }]
+}
+```
+
+### HTTP Recorder
+
+This recorder will send measured data as JSON object in the body to the configured `endpoint` using HTTP POST. The `endpoint` can contain dynamic values.
+
+Optionally `headers` can be configured to be sent in the request.
+
+> `Content-Type` header should not be provided and if so will not be used since it is fixed to `application/json`.
+
+Example configuration:
+
+```json
+{
+    "recorders": [{
+        "type": "http",
+        "config": {
+            "endpoint": "https://host/api/temperature/{device_id}",
+            "headers": [
+                { "Authorization": "Bearer ABCDE12345" }
+            ]
+        }
+    }]
+}
+```

--- a/README.md
+++ b/README.md
@@ -85,10 +85,16 @@ Example configuration:
     "recorders": [{
         "type": "http",
         "config": {
-            "endpoint": "https://host/api/temperature/{device_id}",
-            "headers": [
-                { "Authorization": "Bearer ABCDE12345" }
-            ]
+            "uri": "https://host/api/temperature/{device_id}",
+            "json-template": {
+                "celsius": "{celsius}",
+                "fahrenheit": "{fahrenheit}",
+                "timestamp": "{timestamp}",
+                "device_id": "{device_id}"
+            },
+            "headers": {
+                "Authorization": "Bearer ABCDE12345"
+            }
         }
     }]
 }

--- a/RecorderFactory.py
+++ b/RecorderFactory.py
@@ -1,4 +1,5 @@
 from Recorders import Recorder, PrintRecorder, FileRecorder
+from HttpRecorder import HttpRecorder
 
 def create_print_recorder(config):
     return PrintRecorder(config)
@@ -6,7 +7,11 @@ def create_print_recorder(config):
 def create_file_recorder(config):
     return FileRecorder(config)
 
+def create_http_recorder(config):
+    return HttpRecorder(config)
+
 recorderInitializers = dict([
+    ('http', create_http_recorder),
     ('print', create_print_recorder),
     ('file', create_file_recorder)])
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,6 @@
 {
     "read-interval": 30,
-    "recorders": [
-        {
+    "recorders": [{
             "type": "print",
             "config": {
                 "format": "{device_id} C {celsius} / F {fahrenheit}"
@@ -18,13 +17,13 @@
         {
             "type": "http",
             "config": {
-                "endpoint": "http://localhost:8889/temperature/{device_id}",
-		"method": "POST",
-                "headers": { "Authorization": "Bearer ABCDE12345" },
-		"json_template": {"celsius": "{celsius}",
-				  "fahrenheit": "{fahrenheit}",
-				  "timestamp": "{timestamp}",
-				  "device_id": "{device_id}"}
+                "uri": "http://localhost:8889/temperature/{device_id}",
+                "json-template": {
+                    "celsius": "{celsius}",
+                    "fahrenheit": "{fahrenheit}",
+                    "timestamp": "{timestamp}",
+                    "device_id": "{device_id}"
+                }
             }
         }
     ]

--- a/config.json
+++ b/config.json
@@ -18,8 +18,10 @@
         {
             "type": "http",
             "config": {
-                "endpoint": "https://host/api/temperature/",
-                "method": "POST"
+                "endpoint": "https://host/api/temperature/{device_id}",
+                "headers": [
+                    { "Authorization": "Bearer ABCDE12345" }
+                ]
             }
         }
     ]

--- a/config.json
+++ b/config.json
@@ -14,6 +14,13 @@
                 "container": "/temperaturemonitor/",
                 "extension": ".log"
             }
+        },
+        {
+            "type": "http",
+            "config": {
+                "endpoint": "https://host/api/temperature/",
+                "method": "POST"
+            }
         }
     ]
 }

--- a/config.json
+++ b/config.json
@@ -11,17 +11,20 @@
             "type": "file",
             "config": {
                 "format": "{timestamp},{celsius},C",
-                "container": "/temperaturemonitor/",
+                "container": "temperaturemonitor/",
                 "extension": ".log"
             }
         },
         {
             "type": "http",
             "config": {
-                "endpoint": "https://host/api/temperature/{device_id}",
-                "headers": [
-                    { "Authorization": "Bearer ABCDE12345" }
-                ]
+                "endpoint": "http://localhost:8889/temperature/{device_id}",
+		"method": "POST",
+                "headers": { "Authorization": "Bearer ABCDE12345" },
+		"json_template": {"celsius": "{celsius}",
+				  "fahrenheit": "{fahrenheit}",
+				  "timestamp": "{timestamp}",
+				  "device_id": "{device_id}"}
             }
         }
     ]

--- a/httpserver.py
+++ b/httpserver.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+import tornado.ioloop
+import tornado.web
+import tornado.escape
+import sys
+
+class LogHandler(tornado.web.RequestHandler):
+    def post(self, device_id):
+        data = tornado.escape.json_decode(self.request.body)
+        sys.stderr.write("Received headers: %s\n"%str(self.request.headers))
+        sys.stderr.write("Received payload: %s\n"%str(data))
+        self.finish({'status': 'ok'})
+
+def make_app():
+    return tornado.web.Application([
+        (r"/temperature/([^/]+)", LogHandler)])
+
+if __name__=='__main__':
+    app = make_app()
+    app.listen(8889)
+    tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
Hey, I took your http-recorder branch and made a simple HTTP recorder implementation on it.

The HTTP recorder constructs a JSON payload based on a measurement. The config for the HTTP Recorder contains a `json_template`, and the HTTP recorder expects it to contain string values for each key. Values are formatted using the same template values as in other recorders.

I included a simple HTTP server based on Tornado that prints the POSTed measurements.

Happy hacktoberfest!